### PR TITLE
[WR] use single docker-compose command to run back and front end

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+processor:
+  build: ../data-processor/.
+  links:
+    - queue
+    - db
+  environment:
+    VIP_DP_AWS_ACCESS_KEY:
+    VIP_DP_AWS_SECRET_KEY:
+    VIP_DP_S3_BUCKET:
+    VIP_DP_SQS_REGION:
+    VIP_DP_SQS_QUEUE:
+    VIP_DP_SQS_FAIL_QUEUE:
+    VIP_DP_RABBITMQ_EXCHANGE:
+queue:
+  image: rabbitmq:3.4.3-management
+  ports:
+    - "15672"
+  hostname: qa-engine-rabbit
+db:
+  image: postgres:9.4.1
+  ports:
+    - "5432"
+  environment:
+    POSTGRES_USER:
+    POSTGRES_PASSWORD:
+metis:
+  build: ../Metis/.
+  links:
+    - mongo
+    - db
+    - processor
+  ports:
+    - 4000:4000
+mongo:
+  build: ../Metis/data/
+  ports:
+    - 27017:27017 
+    - 28017:28017

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 processor:
-  build: ../data-processor/.
+  build: ../data-processor/
   links:
-    - queue
+    - rabbitmq
     - db
   environment:
     VIP_DP_AWS_ACCESS_KEY:
@@ -11,8 +11,8 @@ processor:
     VIP_DP_SQS_QUEUE:
     VIP_DP_SQS_FAIL_QUEUE:
     VIP_DP_RABBITMQ_EXCHANGE:
-queue:
-  image: rabbitmq:3.4.3-management
+rabbitmq:
+  image: rabbitmq:3.5.3-management
   ports:
     - "15672"
   hostname: qa-engine-rabbit
@@ -24,7 +24,7 @@ db:
     POSTGRES_USER:
     POSTGRES_PASSWORD:
 metis:
-  build: ../Metis/.
+  build: ../Metis/
   links:
     - mongo
     - db

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,0 +1,13 @@
+{:aws {:creds {:access-key #resource-config/env "VIP_DP_AWS_ACCESS_KEY"
+               :secret-key #resource-config/env "VIP_DP_AWS_SECRET_KEY"}
+       :s3 {:bucket #resource-config/env "VIP_DP_S3_BUCKET"}
+       :sqs {:region #aws/region #resource-config/env "VIP_DP_SQS_REGION"
+             :queue #resource-config/env "VIP_DP_SQS_QUEUE"
+             :fail-queue #resource-config/env "VIP_DP_SQS_FAIL_QUEUE"}}
+ :postgres {:host #resource-config/env "DB_PORT_5432_TCP_ADDR"
+            :port #resource-config/env "DB_PORT_5432_TCP_PORT"
+            :user #resource-config/env "DB_ENV_POSTGRES_USER"
+            :password #resource-config/env "DB_ENV_POSTGRES_PASSWORD"}
+ :rabbit-mq {:connection {:host #resource-config/env "QUEUE_PORT_5672_TCP_ADDR"
+                          :port #resource-config/edn #resource-config/env "QUEUE_PORT_5672_TCP_PORT"}
+             :exchange #resource-config/env "VIP_DP_RABBITMQ_EXCHANGE"}}

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -8,6 +8,6 @@
             :port #resource-config/env "DB_PORT_5432_TCP_PORT"
             :user #resource-config/env "DB_ENV_POSTGRES_USER"
             :password #resource-config/env "DB_ENV_POSTGRES_PASSWORD"}
- :rabbit-mq {:connection {:host #resource-config/env "QUEUE_PORT_5672_TCP_ADDR"
-                          :port #resource-config/edn #resource-config/env "QUEUE_PORT_5672_TCP_PORT"}
-             :exchange #resource-config/env "VIP_DP_RABBITMQ_EXCHANGE"}}
+ :rabbitmq {:connection {:host #resource-config/env "RABBITMQ_PORT_5672_TCP_ADDR"
+                         :port #resource-config/edn #resource-config/env "RABBITMQ_PORT_5672_TCP_PORT"}
+            :exchange #resource-config/env "VIP_DP_RABBITMQ_EXCHANGE"}}


### PR DESCRIPTION
[Pivotal Card](https://www.pivotaltracker.com/story/show/94877910)

This should allow us to run both data-processor and Metis with a single `docker-compose build && docker-compose run` command.
