### PR TITLE
[WR] add env var for new relic browser key

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ metis:
     STORMPATH_API_KEY_ID:
     STORMPATH_API_KEY_SECRET:
     STORMPATH_APP_HREF:
+    NEW_RELIC_BROWSER_LICENSE_KEY:
   links:
     - db
     - processor


### PR DESCRIPTION
Related to [this pr.](https://github.com/votinginfoproject/Metis/pull/282) Simply adds an env var to the docker-compose script here.
