### PR TITLE
Let data-suite run alongside host-native services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,16 +4,19 @@ processor:
     - rabbitmq
     - db
   env_file: .env
+
 rabbitmq:
   image: rabbitmq:3.5.3-management
   ports:
-    - "15672"
+    - 55672:15672
   hostname: qa-engine-rabbit
+
 db:
   image: postgres:9.4.1
   ports:
-    - 5432:5432
+    - 55432:5432
   env_file: .env
+
 metis:
   build: ../Metis/
   env_file: .env
@@ -22,4 +25,4 @@ metis:
     - processor
     - rabbitmq
   ports:
-    - 4000:4000
+    - 54000:4000


### PR DESCRIPTION
When I start a production-like docker system, I don't want to have to
turn of any services that I've got running locally. Expose the
dockerized Postgres server on `55432` so it doesn't clash with your
local Postgres server. The RabbitMQ console lives on `55672` and the
dashboard lives on `54000`.